### PR TITLE
Prevent comments reply button text from overflowing

### DIFF
--- a/assets/css/comments.css
+++ b/assets/css/comments.css
@@ -230,8 +230,7 @@
     }
 
     .post-comment-reply_btn button {
-        padding-left: 4.75rem;
-        padding-right: 4.75rem;
+        padding: .5rem 3rem;
     }
 
     .post-comment-indent {


### PR DESCRIPTION
This PR prevents the comments reply button text from being displayed on multiple lines