### PR TITLE
Make related posts consistent when no suggestions are available

### DIFF
--- a/assets/scss/_posts-related.scss
+++ b/assets/scss/_posts-related.scss
@@ -11,6 +11,8 @@
     }
 
     .post-related {
+      min-width: 20rem;
+      min-height: 23rem;
       display: flex;
       flex-direction: column;
       margin: 1.2rem 1.55rem;
@@ -47,7 +49,7 @@
     .post-related {
       display: flex;
       flex-wrap: wrap;
-      min-width: 75vw;
+      max-width: 75vw;
     }
   }
 }

--- a/layouts/partials/pagination-related-embed.html
+++ b/layouts/partials/pagination-related-embed.html
@@ -1,0 +1,16 @@
+<a href="{{ .RelPermalink }}">
+    <div class="post-related">
+        <div class="post-related-date">{{ .Date.Format "Jan 2, 2006" }}</div>
+        <div class="post-related-title">{{ .Title }}</div>
+        <div class="post-related-cover">
+            {{ with .Resources }}
+                {{ with .GetMatch "{cover.*,*.jpg,*.png,*.jpeg}" }}
+                    {{ $cover := .Resize "600x" }}
+                    {{ with $cover }}
+                        <img src="{{ .Permalink }}"/>
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        </div>
+    </div>
+</a>

--- a/layouts/partials/pagination-related.html
+++ b/layouts/partials/pagination-related.html
@@ -7,50 +7,25 @@
 
         {{ $related := .Site.RegularPages.Related . | first 4 }}
 
-        {{ if eq (len $related) 0 }}
-            <div class="pagination__buttons">
+        <div class="posts-related-container">
+            {{ if eq (len $related) 0 }}
+
                 {{ if .NextInSection }}
-                <span class="button previous">
-                    <a href="{{ .NextInSection.Permalink }}">
-                        <span class="button__icon">←</span>
-                        <span class="button__text">{{ .NextInSection.Title }}</span>
-                    </a>
-                </span>
+                    {{ partial "pagination-related-embed.html" .NextInSection }}
                 {{ end }}
 
                 {{ if .PrevInSection }}
-                <span class="button next">
-                    <a href="{{ .PrevInSection.Permalink }}">
-                        <span class="button__text">{{ .PrevInSection.Title }}</span>
-                        <span class="button__icon">→</span>
-                    </a>
-                </span>
+                    {{ partial "pagination-related-embed.html" .PrevInSection }}
                 {{ end }}
-            </div>
-        {{ else }}
-            {{ with $related }}
-            <!-- <h3>See Also</h3> -->
-                <div class="posts-related-container">
-                    {{ range . }}
-                        <a href="{{ .RelPermalink }}">
-                            <div class="post-related">
-                                <div class="post-related-date">{{ .Date.Format "Jan 2, 2006" }}</div>
-                                <div class="post-related-title">{{ .Title }}</div>
-                                <div class="post-related-cover">
-                                    {{ with .Resources }}
-                                        {{ with .GetMatch "{cover.*,*.jpg,*.png,*.jpeg}" }}
-                                            {{ $cover := .Resize "600x" }}
-                                            {{ with $cover }}
-                                                <img src="{{ .Permalink }}"/>
-                                            {{ end }}
-                                        {{ end }}
-                                    {{ end }}
-                                </div>
-                            </div>
-                        </a>
-                    {{ end }}
-                </div>
+
+            {{ else }}
+                {{ with $related }}
+                        {{ range . }}
+                            {{ partial "pagination-related-embed.html" . }}
+                        {{ end }}
+                {{ end }}
             {{ end }}
-        {{ end }}
+        </div>
+
     </div>
 {{ end }}


### PR DESCRIPTION
This PR makes the related posts items the same size, and also same format for both suggestions and when no suggestions are available. Also, the related post items have been refactored into pagination-related-embed.html