### PR TITLE
Remove role attribute on main tag

### DIFF
--- a/assets/scss/_main.scss
+++ b/assets/scss/_main.scss
@@ -67,9 +67,9 @@ h1 {
 	100% {background-position: 100%;}
 }
 
-main[role="main"] {
+main[class="homepage"] {
+  margin: 4em 5vw 0 5vw;
   h1 {
-
     margin-top: -2rem;
     font-size: 4.5rem;
     font-weight: 900;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-    <main role="main" style="margin: 4em 5vw 0 5vw;">
+    <main class="homepage">
         <div>
             {{ if .Site.Params.Portrait.Path }}
                <img src="{{ .Site.Params.Portrait.Path }}" class="circle" alt="{{ .Site.Params.Portrait.Alt }}" style="max-width:{{ .Site.Params.Portrait.MaxWidth }}" />


### PR DESCRIPTION
This is being removed because the `main` role is unnecessary for element `main` according to the Nu HTML Checker tool by W3.org here: https://validator.w3.org